### PR TITLE
added necessary commands to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Physicians and Mentors
 
 
-## TO MAKE SURE SCRIPTS CAN BE RAN, RUN THE FOLLOWING:
+## TO MAKE SURE SCRIPTS CAN BE RAN, RUN THE FOLLOWING: with dos2unix installed!!!
 '''
 chmod +x build_local.sh
 chmod +x connect_local.sh
+dos2unix build_local.sh
+dos2unix connect_local.sh
 '''
 
 
@@ -12,6 +14,7 @@ chmod +x connect_local.sh
 '''
 ./build_local.sh
 '''
+
 ### (IN CONTAINER BASH) also run this to setup the db:
 '''
 rails db:create


### PR DESCRIPTION
The README didn't account for the fact that sometimes .sh files get a few characters messed with when they come from or go to a windows system. Essentially, just copy paste the 4 commands in the top to make sure the scripts can be ran.